### PR TITLE
Revert "Delete `stdsimd` feature."

### DIFF
--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::needless_range_loop)]
+#![feature(stdsimd)]
 #![feature(specialization)]
 #![cfg_attr(not(test), no_std)]
 


### PR DESCRIPTION
This reverts commit 8e367f19384eedb408610cb783123e2e6eb4d8e8.