### PR TITLE
Introduce poseidon2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["field", "maybe_rayon", "plonky2", "starky", "util"]
+members = ["field", "maybe_rayon", "plonky2", "poseidon2_plonky2", "starky", "util"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/plonky2/src/hash/arch/aarch64/mod.rs
+++ b/plonky2/src/hash/arch/aarch64/mod.rs
@@ -1,2 +1,2 @@
 #[cfg(target_feature = "neon")]
-pub(crate) mod poseidon_goldilocks_neon;
+pub mod poseidon_goldilocks_neon;

--- a/plonky2/src/hash/arch/aarch64/poseidon_goldilocks_neon.rs
+++ b/plonky2/src/hash/arch/aarch64/poseidon_goldilocks_neon.rs
@@ -174,7 +174,7 @@ unsafe fn const_layer_full(
 /// Full S-box.
 #[inline(always)]
 #[unroll_for_loops]
-unsafe fn sbox_layer_full(state: [u64; WIDTH]) -> [u64; WIDTH] {
+pub unsafe fn sbox_layer_full(state: [u64; WIDTH]) -> [u64; WIDTH] {
     // This is done in scalar. S-boxes in vector are only slightly slower throughput-wise but have
     // an insane latency (~100 cycles) on the M1.
 

--- a/plonky2/src/hash/arch/mod.rs
+++ b/plonky2/src/hash/arch/mod.rs
@@ -2,4 +2,4 @@
 pub(crate) mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
-pub(crate) mod aarch64;
+pub mod aarch64;

--- a/plonky2/src/hash/mod.rs
+++ b/plonky2/src/hash/mod.rs
@@ -1,7 +1,7 @@
 //! plonky2 hashing logic for in-circuit hashing and Merkle proof verification
 //! as well as specific hash functions implementation.
 
-mod arch;
+pub mod arch;
 pub mod hash_types;
 pub mod hashing;
 pub mod keccak;

--- a/poseidon2_plonky2/Cargo.toml
+++ b/poseidon2_plonky2/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.69"
-plonky2 = "0.2.2"
+plonky2 = { path = "../plonky2" }
 rstest = "0.17.0"
 serial_test = "1.0.0"
 unroll = "0.1.5"
 
 [dev-dependencies]
-criterion = {version = "0.4.0", default-features = false }
+criterion = { version = "0.4.0", default-features = false }
 env_logger = "0.10.0"
 log = "0.4.17"
 rand_chacha = "0.3.1"
@@ -38,4 +38,3 @@ harness = false
 [[bench]]
 name = "recursion"
 harness = false
-

--- a/poseidon2_plonky2/Cargo.toml
+++ b/poseidon2_plonky2/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "poseidon2_plonky2"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.69"
+plonky2 = "0.2.2"
+rstest = "0.17.0"
+serial_test = "1.0.0"
+unroll = "0.1.5"
+
+[dev-dependencies]
+criterion = {version = "0.4.0", default-features = false }
+env_logger = "0.10.0"
+log = "0.4.17"
+rand_chacha = "0.3.1"
+serde_cbor = "0.11.2"
+tynm = { version = "0.1.6", default-features = false }
+
+[target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
+jemallocator = "0.5.0"
+
+[[bench]]
+name = "hashing"
+harness = false
+
+[[bench]]
+name = "merkle"
+harness = false
+
+[[bench]]
+name = "base_proof"
+harness = false
+
+[[bench]]
+name = "recursion"
+harness = false
+

--- a/poseidon2_plonky2/LICENSE-APACHE
+++ b/poseidon2_plonky2/LICENSE-APACHE
@@ -1,0 +1,202 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/poseidon2_plonky2/LICENSE-MIT
+++ b/poseidon2_plonky2/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 The Plonky2 Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/poseidon2_plonky2/benches/allocator/mod.rs
+++ b/poseidon2_plonky2/benches/allocator/mod.rs
@@ -1,0 +1,6 @@
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;

--- a/poseidon2_plonky2/benches/base_proof.rs
+++ b/poseidon2_plonky2/benches/base_proof.rs
@@ -1,0 +1,79 @@
+#![feature(generic_const_exprs)]
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use plonky2::field::extension::Extendable;
+use plonky2::field::goldilocks_field::GoldilocksField;
+use plonky2::hash::hash_types::RichField;
+use plonky2::hash::poseidon::PoseidonHash;
+use plonky2::plonk::circuit_data::CircuitConfig;
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig};
+use poseidon2_plonky2::poseidon2_goldilock::Poseidon2GoldilocksConfig;
+use poseidon2_plonky2::poseidon2_hash::Poseidon2Hash;
+use tynm::type_name;
+
+use crate::circuits::BaseCircuit;
+
+mod circuits;
+
+fn bench_base_proof<
+    F: RichField + Extendable<D>,
+    const D: usize,
+    C: GenericConfig<D, F = F>,
+    H: Hasher<F> + AlgebraicHasher<F>,
+>(
+    c: &mut Criterion,
+) {
+    let mut group = c.benchmark_group(&format!(
+        "base-proof<{}, {}>",
+        type_name::<C>(),
+        type_name::<H>()
+    ));
+
+    let config = CircuitConfig::standard_recursion_config();
+    for degree in [12, 14, 16] {
+        group.bench_function(
+            format!("build circuit for degree {}", degree).as_str(),
+            |b| {
+                b.iter_with_large_drop(|| {
+                    BaseCircuit::<F, C, D, H>::build_base_circuit(config.clone(), degree);
+                })
+            },
+        );
+
+        let base_circuit = BaseCircuit::<F, C, D, H>::build_base_circuit(config.clone(), degree);
+
+        group.bench_function(format!("prove for degree {}", degree).as_str(), |b| {
+            b.iter_batched(
+                || F::rand(),
+                |init| base_circuit.generate_base_proof(init).unwrap(),
+                BatchSize::PerIteration,
+            )
+        });
+
+        let proof = base_circuit.generate_base_proof(F::rand()).unwrap();
+
+        group.bench_function(format!("verify for degree {}", degree).as_str(), |b| {
+            b.iter_batched(
+                || (base_circuit.get_circuit_data(), proof.clone()),
+                |(data, proof)| data.verify(proof).unwrap(),
+                BatchSize::PerIteration,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+fn benchmark(c: &mut Criterion) {
+    const D: usize = 2;
+    type F = GoldilocksField;
+    bench_base_proof::<F, D, PoseidonGoldilocksConfig, PoseidonHash>(c);
+    bench_base_proof::<F, D, Poseidon2GoldilocksConfig, PoseidonHash>(c);
+    bench_base_proof::<F, D, PoseidonGoldilocksConfig, Poseidon2Hash>(c);
+    bench_base_proof::<F, D, Poseidon2GoldilocksConfig, Poseidon2Hash>(c);
+}
+
+criterion_group!(name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark);
+criterion_main!(benches);

--- a/poseidon2_plonky2/benches/circuits/mod.rs
+++ b/poseidon2_plonky2/benches/circuits/mod.rs
@@ -1,0 +1,105 @@
+use std::marker::PhantomData;
+
+use anyhow::Result;
+use plonky2::field::extension::Extendable;
+use plonky2::gates::arithmetic_base::ArithmeticGate;
+use plonky2::hash::hash_types::RichField;
+use plonky2::hash::hashing::hash_n_to_m_no_pad;
+use plonky2::iop::target::Target;
+use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::{CircuitConfig, CircuitData};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use plonky2::plonk::proof::ProofWithPublicInputs;
+
+/// Data structure with all input/output targets and the `CircuitData` for the circuit proven
+/// in base proofs. The circuit is designed to be representative of a common base circuit
+/// operating on a common public state employing also some private data.
+/// The computation performed on the state was chosen to employ commonly used gates, such as
+/// arithmetic and hash ones
+pub struct BaseCircuit<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+    H: Hasher<F> + AlgebraicHasher<F>,
+> {
+    private_input: Target,
+    public_input: Target,
+    public_output: Target,
+    circuit_data: CircuitData<F, C, D>,
+    num_powers: usize,
+    _hasher: PhantomData<H>,
+}
+
+impl<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        const D: usize,
+        H: Hasher<F> + AlgebraicHasher<F>,
+    > BaseCircuit<F, C, D, H>
+{
+    pub fn build_base_circuit(config: CircuitConfig, degree: usize) -> Self {
+        let num_gates: usize = 1usize << degree;
+        let num_ops = ArithmeticGate::new_from_config(&config).num_ops;
+        // the number of gates in the circuit depending on `powers` is
+        // `N = powers + 1 + ceil((2 + powers)/num_ops) + 3`.
+        // Thus, to obtain a circuit with N <= num_gates gates, we set `powers` as follows
+        let powers = ((num_gates - 5) * num_ops - 2) / (num_ops + 1);
+
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let mut res_t = builder.add_virtual_public_input();
+        let init_t = res_t;
+        let zero = builder.zero();
+        let to_be_hashed_t = builder.add_virtual_target();
+        for _ in 0..powers {
+            res_t = builder.mul(res_t, init_t);
+            res_t = builder.hash_n_to_m_no_pad::<H>(vec![res_t, to_be_hashed_t, zero, zero], 1)[0];
+        }
+
+        let out_t = builder.add_virtual_public_input();
+        let is_eq_t = builder.is_equal(out_t, res_t);
+        builder.assert_one(is_eq_t.target);
+
+        let data = builder.build::<C>();
+
+        assert_eq!(data.common.degree_bits(), degree);
+
+        Self {
+            private_input: to_be_hashed_t,
+            public_input: init_t,
+            public_output: out_t,
+            circuit_data: data,
+            num_powers: powers,
+            _hasher: PhantomData::<H>,
+        }
+    }
+
+    pub fn generate_base_proof(&self, init: F) -> Result<ProofWithPublicInputs<F, C, D>> {
+        let mut pw = PartialWitness::<F>::new();
+
+        pw.set_target(self.public_input, init);
+        let to_be_hashed = F::rand();
+        pw.set_target(self.private_input, to_be_hashed);
+        let mut res = init;
+        for _ in 0..self.num_powers {
+            res = res.mul(init);
+            res =
+                hash_n_to_m_no_pad::<_, H::Permutation>(&[res, to_be_hashed, F::ZERO, F::ZERO], 1)
+                    [0];
+        }
+
+        pw.set_target(self.public_output, res);
+
+        let proof = self.circuit_data.prove(pw)?;
+
+        self.circuit_data.verify(proof.clone())?;
+
+        assert_eq!(proof.public_inputs[1], res);
+
+        Ok(proof)
+    }
+
+    pub fn get_circuit_data(&self) -> &CircuitData<F, C, D> {
+        &self.circuit_data
+    }
+}

--- a/poseidon2_plonky2/benches/hashing.rs
+++ b/poseidon2_plonky2/benches/hashing.rs
@@ -1,0 +1,80 @@
+mod allocator;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use plonky2::field::goldilocks_field::GoldilocksField;
+use plonky2::field::types::Sample;
+use plonky2::hash::hash_types::{BytesHash, RichField};
+use plonky2::hash::keccak::KeccakHash;
+use plonky2::hash::poseidon::{Poseidon, SPONGE_WIDTH};
+use plonky2::plonk::config::Hasher;
+use poseidon2_plonky2::poseidon2_hash::{Poseidon2, WIDTH};
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha12Rng;
+use tynm::type_name;
+
+pub(crate) fn bench_keccak<F: RichField>(c: &mut Criterion) {
+    let mut rng = ChaCha12Rng::seed_from_u64(38u64);
+    c.bench_function("keccak256", |b| {
+        b.iter_batched(
+            || {
+                (
+                    BytesHash::<32>::sample(&mut rng),
+                    BytesHash::<32>::sample(&mut rng),
+                )
+            },
+            |(left, right)| <KeccakHash<32> as Hasher<F>>::two_to_one(left, right),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+pub(crate) fn bench_poseidon<F: Poseidon>(c: &mut Criterion) {
+    let mut rng = ChaCha12Rng::seed_from_u64(42u64);
+    c.bench_function(
+        &format!("poseidon<{}, {}>", type_name::<F>(), SPONGE_WIDTH),
+        |b| {
+            b.iter_batched(
+                || {
+                    (0..SPONGE_WIDTH)
+                        .map(|_| F::sample(&mut rng))
+                        .collect::<Vec<_>>()
+                        .try_into()
+                        .unwrap()
+                },
+                |state| F::poseidon(state),
+                BatchSize::SmallInput,
+            )
+        },
+    );
+}
+
+pub(crate) fn bench_poseidon_2<F: Poseidon2>(c: &mut Criterion) {
+    let mut rng = ChaCha12Rng::seed_from_u64(42u64);
+    c.bench_function(
+        &format!("poseidon2<{}, {}>", type_name::<F>(), WIDTH),
+        |b| {
+            b.iter_batched(
+                || {
+                    (0..WIDTH)
+                        .map(|_| F::sample(&mut rng))
+                        .collect::<Vec<_>>()
+                        .try_into()
+                        .unwrap()
+                },
+                |state| F::poseidon2(state),
+                BatchSize::SmallInput,
+            )
+        },
+    );
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    bench_poseidon::<GoldilocksField>(c);
+    bench_poseidon_2::<GoldilocksField>(c);
+    bench_keccak::<GoldilocksField>(c);
+}
+
+criterion_group!(name = benches;
+    config = Criterion::default().sample_size(500);
+    targets = criterion_benchmark);
+criterion_main!(benches);

--- a/poseidon2_plonky2/benches/merkle.rs
+++ b/poseidon2_plonky2/benches/merkle.rs
@@ -1,0 +1,44 @@
+#![feature(generic_const_exprs)]
+
+mod allocator;
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use plonky2::field::goldilocks_field::GoldilocksField;
+use plonky2::hash::hash_types::RichField;
+use plonky2::hash::keccak::KeccakHash;
+use plonky2::hash::merkle_tree::MerkleTree;
+use plonky2::hash::poseidon::PoseidonHash;
+use plonky2::plonk::config::Hasher;
+use poseidon2_plonky2::poseidon2_hash::Poseidon2Hash;
+use tynm::type_name;
+
+const ELEMS_PER_LEAF: usize = 135;
+
+pub(crate) fn bench_merkle_tree<F: RichField, H: Hasher<F>>(c: &mut Criterion) {
+    let mut group = c.benchmark_group(&format!(
+        "merkle-tree<{}, {}>",
+        type_name::<F>(),
+        type_name::<H>()
+    ));
+    group.sample_size(30);
+
+    for size_log in [13, 14, 15] {
+        let size = 1 << size_log;
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            b.iter_batched(
+                || vec![F::rand_vec(ELEMS_PER_LEAF); size],
+                |leaves| MerkleTree::<F, H>::new(leaves, 0),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    bench_merkle_tree::<GoldilocksField, PoseidonHash>(c);
+    bench_merkle_tree::<GoldilocksField, Poseidon2Hash>(c);
+    bench_merkle_tree::<GoldilocksField, KeccakHash<25>>(c);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/poseidon2_plonky2/benches/recursion.rs
+++ b/poseidon2_plonky2/benches/recursion.rs
@@ -1,0 +1,247 @@
+#![feature(generic_const_exprs)]
+
+use std::marker::PhantomData;
+
+use anyhow::Result;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use plonky2::field::extension::Extendable;
+use plonky2::field::goldilocks_field::GoldilocksField;
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::{
+    CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget,
+};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, PoseidonGoldilocksConfig};
+use plonky2::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
+use poseidon2_plonky2::poseidon2_goldilock::Poseidon2GoldilocksConfig;
+use tynm::type_name;
+
+use crate::circuits::BaseCircuit;
+
+mod circuits;
+
+macro_rules! pretty_print {
+    ($($arg:tt)*) => {
+        print!("\x1b[0;36mINFO ===========>\x1b[0m ");
+        println!($($arg)*);
+    }
+}
+
+/// Data structure with all input/output targets and the `CircuitData` for each circuit employed
+/// to recursively shrink a proof up to the recursion threshold. The data structure contains a set
+/// of targets and a `CircuitData` for each shrink step
+struct ShrinkCircuit<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    InnerC: GenericConfig<D, F = F>,
+    const D: usize,
+> {
+    proof_targets: Vec<ProofWithPublicInputsTarget<D>>,
+    circuit_data: Vec<CircuitData<F, C, D>>,
+    inner_data: Vec<VerifierCircuitTarget>,
+    _inner_c: PhantomData<InnerC>,
+}
+
+const RECURSION_THRESHOLD: usize = 12;
+
+impl<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        InnerC: GenericConfig<D, F = F>,
+        const D: usize,
+    > ShrinkCircuit<F, C, InnerC, D>
+where
+    InnerC::Hasher: AlgebraicHasher<F>,
+    C::Hasher: AlgebraicHasher<F>,
+{
+    pub fn build_shrink_circuit(inner_cd: &CommonCircuitData<F, D>, config: CircuitConfig) -> Self {
+        let mut circuit_data = inner_cd;
+        let mut shrink_circuit = Self {
+            proof_targets: Vec::new(),
+            circuit_data: Vec::new(),
+            inner_data: Vec::new(),
+            _inner_c: PhantomData::<InnerC>,
+        };
+        while circuit_data.degree_bits() > RECURSION_THRESHOLD {
+            let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+            //let mut pw = PartialWitness::new();
+            let pt = builder.add_virtual_proof_with_pis(circuit_data);
+
+            let inner_data =
+                builder.add_virtual_verifier_data(circuit_data.config.fri_config.cap_height);
+            if shrink_circuit.num_shrink_steps() > 0 {
+                builder.verify_proof::<C>(&pt, &inner_data, circuit_data);
+            } else {
+                builder.verify_proof::<InnerC>(&pt, &inner_data, circuit_data);
+            }
+
+            for &pi_t in pt.public_inputs.iter() {
+                let t = builder.add_virtual_public_input();
+                builder.connect(pi_t, t);
+            }
+
+            let data = builder.build::<C>();
+
+            shrink_circuit.proof_targets.push(pt);
+            shrink_circuit.circuit_data.push(data);
+            shrink_circuit.inner_data.push(inner_data);
+            circuit_data = &shrink_circuit.circuit_data.last().unwrap().common;
+        }
+
+        shrink_circuit
+    }
+
+    fn set_witness<GC: GenericConfig<D, F = F>>(
+        pw: &mut PartialWitness<F>,
+        proof: &ProofWithPublicInputs<F, GC, D>,
+        pt: &ProofWithPublicInputsTarget<D>,
+        inner_data: &VerifierCircuitTarget,
+        circuit_data: &CircuitData<F, GC, D>,
+    ) where
+        GC::Hasher: AlgebraicHasher<F>,
+    {
+        pw.set_proof_with_pis_target(pt, proof);
+        pw.set_cap_target(
+            &inner_data.constants_sigmas_cap,
+            &circuit_data.verifier_only.constants_sigmas_cap,
+        );
+        pw.set_hash_target(
+            inner_data.circuit_digest,
+            circuit_data.verifier_only.circuit_digest,
+        );
+    }
+
+    pub fn shrink_proof<'a>(
+        &'a self,
+        inner_proof: ProofWithPublicInputs<F, InnerC, D>,
+        inner_cd: &'a CircuitData<F, InnerC, D>,
+    ) -> Result<ProofWithPublicInputs<F, C, D>> {
+        let mut proof = None;
+        let mut circuit_data = None;
+
+        for ((pt, cd), inner_data) in self
+            .proof_targets
+            .iter()
+            .zip(self.circuit_data.iter())
+            .zip(self.inner_data.iter())
+        {
+            let mut pw = PartialWitness::new();
+            match (proof, circuit_data) {
+                (None, None) => Self::set_witness(&mut pw, &inner_proof, pt, inner_data, inner_cd),
+                (Some(inner_proof), Some(inner_cd)) => {
+                    Self::set_witness(&mut pw, &inner_proof, pt, inner_data, inner_cd);
+                }
+                _ => unreachable!(),
+            }
+            proof = Some(cd.prove(pw)?);
+            circuit_data = Some(cd);
+        }
+
+        Ok(proof.unwrap())
+    }
+
+    pub fn num_shrink_steps(&self) -> usize {
+        self.circuit_data.len()
+    }
+
+    pub fn get_circuit_data(&self) -> &CircuitData<F, C, D> {
+        self.circuit_data.last().unwrap()
+    }
+}
+
+fn bench_recursive_proof<
+    F: RichField + Extendable<D>,
+    const D: usize,
+    C: GenericConfig<D, F = F>,
+    InnerC: GenericConfig<D, F = F>,
+>(
+    c: &mut Criterion,
+) where
+    InnerC::Hasher: AlgebraicHasher<F>,
+    C::Hasher: AlgebraicHasher<F>,
+{
+    let mut group = c.benchmark_group(&format!(
+        "recursive-proof<{}, {}>",
+        type_name::<C>(),
+        type_name::<InnerC>()
+    ));
+
+    let config = CircuitConfig::standard_recursion_config();
+
+    for degree in [13, 15] {
+        let base_circuit =
+            BaseCircuit::<F, InnerC, D, InnerC::Hasher>::build_base_circuit(config.clone(), degree);
+
+        assert_eq!(base_circuit.get_circuit_data().common.degree_bits(), degree);
+
+        let proof = base_circuit.generate_base_proof(F::rand()).unwrap();
+
+        let inner_cd = &base_circuit.get_circuit_data().common;
+
+        group.bench_function(
+            format!("build circuit for degree {}", degree).as_str(),
+            |b| {
+                b.iter_with_large_drop(|| {
+                    ShrinkCircuit::<F, C, InnerC, D>::build_shrink_circuit(
+                        inner_cd,
+                        config.clone(),
+                    );
+                })
+            },
+        );
+
+        let shrink_circuit =
+            ShrinkCircuit::<F, C, InnerC, D>::build_shrink_circuit(inner_cd, config.clone());
+
+        pretty_print!("shrink steps: {}", shrink_circuit.num_shrink_steps());
+
+        let inner_cd = base_circuit.get_circuit_data();
+
+        group.bench_function(
+            format!("shrinking proof of degree {}", degree).as_str(),
+            |b| {
+                b.iter_batched(
+                    || proof.clone(),
+                    |proof| shrink_circuit.shrink_proof(proof, inner_cd).unwrap(),
+                    BatchSize::PerIteration,
+                )
+            },
+        );
+
+        let shrunk_proof = shrink_circuit.shrink_proof(proof, inner_cd).unwrap();
+        let shrunk_cd = shrink_circuit.get_circuit_data();
+
+        assert_eq!(shrunk_cd.common.degree_bits(), RECURSION_THRESHOLD);
+
+        //let proof_bytes = serde_cbor::to_vec(&shrunk_proof).unwrap();
+        //fancy_print!("Proof length: {} bytes for {} gates", proof_bytes.len(), shrunk_cd.common.degree());
+
+        group.bench_function(
+            format!("verify proof for degree {}", degree).as_str(),
+            |b| {
+                b.iter_batched(
+                    || shrunk_proof.clone(),
+                    |proof| shrunk_cd.verify(proof).unwrap(),
+                    BatchSize::PerIteration,
+                )
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn benchmark(c: &mut Criterion) {
+    const D: usize = 2;
+    type F = GoldilocksField;
+    bench_recursive_proof::<F, D, PoseidonGoldilocksConfig, PoseidonGoldilocksConfig>(c);
+    bench_recursive_proof::<F, D, PoseidonGoldilocksConfig, Poseidon2GoldilocksConfig>(c);
+    bench_recursive_proof::<F, D, Poseidon2GoldilocksConfig, PoseidonGoldilocksConfig>(c);
+    bench_recursive_proof::<F, D, Poseidon2GoldilocksConfig, Poseidon2GoldilocksConfig>(c);
+}
+
+criterion_group!(name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark);
+criterion_main!(benches);

--- a/poseidon2_plonky2/src/lib.rs
+++ b/poseidon2_plonky2/src/lib.rs
@@ -1,0 +1,15 @@
+#![feature(generic_const_exprs)]
+#![allow(clippy::needless_range_loop)]
+
+//! This crate provides an implementation of the Poseidon2 hash function as described in
+//! <https://eprint.iacr.org/2023/323.pdf> that can be seamlessly employed in Plonky2 proving
+//! system. All the necessary traits and data structures necessary for Plonky2 are already
+//! implemented.
+//!
+//! Furthermore, this crate provides a Plonky2 gate and the necessary traits and data structures to
+//! employ this novel hash function in Plonky2 circuits
+extern crate alloc;
+
+pub mod poseidon2_gate;
+pub mod poseidon2_goldilock;
+pub mod poseidon2_hash;

--- a/poseidon2_plonky2/src/poseidon2_gate.rs
+++ b/poseidon2_plonky2/src/poseidon2_gate.rs
@@ -1,0 +1,604 @@
+//! Implementation of a Plonky2 gate for an entire Poseidon2 permutation over a state of width 12
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use core::marker::PhantomData;
+
+use plonky2::field::extension::Extendable;
+use plonky2::field::types::Field;
+use plonky2::gates::gate::Gate;
+use plonky2::gates::util::StridedConstraintConsumer;
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::ext_target::ExtensionTarget;
+use plonky2::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGeneratorRef};
+use plonky2::iop::target::Target;
+use plonky2::iop::wire::Wire;
+use plonky2::iop::witness::{PartitionWitness, Witness, WitnessWrite};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::CommonCircuitData;
+use plonky2::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use plonky2::util::serialization::{Buffer, IoResult, Read, Write};
+
+use crate::poseidon2_hash::{self as poseidon2, Poseidon2, WIDTH};
+
+/// Evaluates a full Poseidon2 permutation with 12 state elements.
+///
+/// This also has some extra features to make it suitable for efficiently verifying Merkle proofs.
+/// It has a flag which can be used to swap the first four inputs with the next four, for ordering
+/// sibling digests.
+#[derive(Debug, Default)]
+pub struct Poseidon2Gate<F: RichField + Extendable<D>, const D: usize>(PhantomData<F>);
+
+impl<F: RichField + Extendable<D>, const D: usize> Poseidon2Gate<F, D> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+
+    /// The wire index for the `i`th input to the permutation.
+    pub fn wire_input(i: usize) -> usize {
+        i
+    }
+
+    /// The wire index for the `i`th output to the permutation.
+    pub fn wire_output(i: usize) -> usize {
+        WIDTH + i
+    }
+
+    /// If this is set to 1, the first four inputs will be swapped with the next four inputs. This
+    /// is useful for ordering hashes in Merkle proofs. Otherwise, this should be set to 0.
+    pub const WIRE_SWAP: usize = 2 * WIDTH;
+
+    const START_DELTA: usize = 2 * WIDTH + 1;
+
+    /// A wire which stores `swap * (input[i + 4] - input[i])`; used to compute the swapped inputs.
+    fn wire_delta(i: usize) -> usize {
+        assert!(i < 4);
+        Self::START_DELTA + i
+    }
+
+    const START_FULL_0: usize = Self::START_DELTA + 4;
+
+    /// A wire which stores the input of the `i`-th S-box of the `round`-th round of the first set
+    /// of full rounds.
+    fn wire_full_sbox_0(round: usize, i: usize) -> usize {
+        debug_assert!(
+            round != 0,
+            "First round S-box inputs are not stored as wires"
+        );
+        debug_assert!(round < poseidon2::HALF_N_FULL_ROUNDS);
+        debug_assert!(i < WIDTH);
+        Self::START_FULL_0 + WIDTH * (round - 1) + i
+    }
+
+    const START_PARTIAL: usize = Self::START_FULL_0 + WIDTH * (poseidon2::HALF_N_FULL_ROUNDS - 1);
+
+    /// A wire which stores the input of the S-box of the `round`-th round of the partial rounds.
+    fn wire_partial_sbox(round: usize) -> usize {
+        debug_assert!(round < poseidon2::N_PARTIAL_ROUNDS);
+        Self::START_PARTIAL + round
+    }
+
+    const START_FULL_1: usize = Self::START_PARTIAL + poseidon2::N_PARTIAL_ROUNDS;
+
+    /// A wire which stores the input of the `i`-th S-box of the `round`-th round of the second set
+    /// of full rounds.
+    fn wire_full_sbox_1(round: usize, i: usize) -> usize {
+        debug_assert!(round < poseidon2::HALF_N_FULL_ROUNDS);
+        debug_assert!(i < WIDTH);
+        Self::START_FULL_1 + WIDTH * round + i
+    }
+
+    /// End of wire indices, exclusive.
+    fn end() -> usize {
+        Self::START_FULL_1 + WIDTH * poseidon2::HALF_N_FULL_ROUNDS
+    }
+}
+
+impl<F: RichField + Extendable<D> + Poseidon2, const D: usize> Gate<F, D> for Poseidon2Gate<F, D> {
+    fn id(&self) -> String {
+        format!("{self:?}<WIDTH={}>", WIDTH)
+    }
+
+    fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {
+        let mut constraints = Vec::with_capacity(self.num_constraints());
+
+        // Assert that `swap` is binary.
+        let swap = vars.local_wires[Self::WIRE_SWAP];
+        constraints.push(swap * (swap - F::Extension::ONE));
+
+        // Assert that each delta wire is set properly: `delta_i = swap * (rhs - lhs)`.
+        for i in 0..4 {
+            let input_lhs = vars.local_wires[Self::wire_input(i)];
+            let input_rhs = vars.local_wires[Self::wire_input(i + 4)];
+            let delta_i = vars.local_wires[Self::wire_delta(i)];
+            constraints.push(swap * (input_rhs - input_lhs) - delta_i);
+        }
+
+        // Compute the possibly-swapped input layer.
+        let mut state = [F::Extension::ZERO; WIDTH];
+        for i in 0..4 {
+            let delta_i = vars.local_wires[Self::wire_delta(i)];
+            let input_lhs = Self::wire_input(i);
+            let input_rhs = Self::wire_input(i + 4);
+            state[i] = vars.local_wires[input_lhs] + delta_i;
+            state[i + 4] = vars.local_wires[input_rhs] - delta_i;
+        }
+        for i in 8..WIDTH {
+            state[i] = vars.local_wires[Self::wire_input(i)];
+        }
+
+        let mut round_ctr = 0;
+
+        // First external matrix
+        <F as Poseidon2>::external_matrix_field(&mut state);
+
+        // First set of full rounds.
+        for r in 0..poseidon2::HALF_N_FULL_ROUNDS {
+            <F as Poseidon2>::constant_layer_field(&mut state, round_ctr);
+            if r != 0 {
+                for i in 0..WIDTH {
+                    let sbox_in = vars.local_wires[Self::wire_full_sbox_0(r, i)];
+                    constraints.push(state[i] - sbox_in);
+                    state[i] = sbox_in;
+                }
+            }
+            <F as Poseidon2>::sbox_layer_field(&mut state);
+            <F as Poseidon2>::external_matrix_field(&mut state);
+            round_ctr += 1;
+        }
+
+        // Partial rounds.
+        for r in 0..(poseidon2::N_PARTIAL_ROUNDS) {
+            state[0] += F::Extension::from_canonical_u64(
+                poseidon2::ALL_ROUND_CONSTANTS[poseidon2::HALF_N_FULL_ROUNDS * WIDTH + r * WIDTH],
+            );
+            let sbox_in = vars.local_wires[Self::wire_partial_sbox(r)];
+            constraints.push(state[0] - sbox_in);
+            state[0] = <F as Poseidon2>::sbox_monomial(sbox_in);
+            <F as Poseidon2>::internal_matrix_field(&mut state);
+        }
+        round_ctr += poseidon2::N_PARTIAL_ROUNDS;
+
+        // Second set of full rounds.
+        for r in 0..poseidon2::HALF_N_FULL_ROUNDS {
+            <F as Poseidon2>::constant_layer_field(&mut state, round_ctr);
+            for i in 0..WIDTH {
+                let sbox_in = vars.local_wires[Self::wire_full_sbox_1(r, i)];
+                constraints.push(state[i] - sbox_in);
+                state[i] = sbox_in;
+            }
+            <F as Poseidon2>::sbox_layer_field(&mut state);
+            <F as Poseidon2>::external_matrix_field(&mut state);
+            round_ctr += 1;
+        }
+
+        for i in 0..WIDTH {
+            constraints.push(state[i] - vars.local_wires[Self::wire_output(i)]);
+        }
+
+        constraints
+    }
+
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
+        // Assert that `swap` is binary.
+        let swap = vars.local_wires[Self::WIRE_SWAP];
+        yield_constr.one(swap * swap.sub_one());
+
+        // Assert that each delta wire is set properly: `delta_i = swap * (rhs - lhs)`.
+        for i in 0..4 {
+            let input_lhs = vars.local_wires[Self::wire_input(i)];
+            let input_rhs = vars.local_wires[Self::wire_input(i + 4)];
+            let delta_i = vars.local_wires[Self::wire_delta(i)];
+            yield_constr.one(swap * (input_rhs - input_lhs) - delta_i);
+        }
+
+        // Compute the possibly-swapped input layer.
+        let mut state = [F::ZERO; WIDTH];
+        for i in 0..4 {
+            let delta_i = vars.local_wires[Self::wire_delta(i)];
+            let input_lhs = Self::wire_input(i);
+            let input_rhs = Self::wire_input(i + 4);
+            state[i] = vars.local_wires[input_lhs] + delta_i;
+            state[i + 4] = vars.local_wires[input_rhs] - delta_i;
+        }
+        for i in 8..WIDTH {
+            state[i] = vars.local_wires[Self::wire_input(i)];
+        }
+
+        let mut round_ctr = 0;
+
+        // First external matrix
+        <F as Poseidon2>::external_matrix(&mut state);
+
+        // First set of full rounds.
+        for r in 0..poseidon2::HALF_N_FULL_ROUNDS {
+            <F as Poseidon2>::constant_layer(&mut state, round_ctr);
+            if r != 0 {
+                for i in 0..WIDTH {
+                    let sbox_in = vars.local_wires[Self::wire_full_sbox_0(r, i)];
+                    yield_constr.one(state[i] - sbox_in);
+                    state[i] = sbox_in;
+                }
+            }
+            <F as Poseidon2>::sbox_layer(&mut state);
+            <F as Poseidon2>::external_matrix(&mut state);
+            round_ctr += 1;
+        }
+
+        // Partial rounds.
+        let mut constant_counter = poseidon2::HALF_N_FULL_ROUNDS * WIDTH;
+        for r in 0..(poseidon2::N_PARTIAL_ROUNDS) {
+            state[0] += F::from_canonical_u64(poseidon2::ALL_ROUND_CONSTANTS[constant_counter]);
+            constant_counter += WIDTH;
+            let sbox_in = vars.local_wires[Self::wire_partial_sbox(r)];
+            yield_constr.one(state[0] - sbox_in);
+            state[0] = <F as Poseidon2>::sbox_monomial(sbox_in);
+            <F as Poseidon2>::internal_matrix(&mut state);
+        }
+        round_ctr += poseidon2::N_PARTIAL_ROUNDS;
+
+        // Second set of full rounds.
+        for r in 0..poseidon2::HALF_N_FULL_ROUNDS {
+            <F as Poseidon2>::constant_layer(&mut state, round_ctr);
+            for i in 0..WIDTH {
+                let sbox_in = vars.local_wires[Self::wire_full_sbox_1(r, i)];
+                yield_constr.one(state[i] - sbox_in);
+                state[i] = sbox_in;
+            }
+            <F as Poseidon2>::sbox_layer(&mut state);
+            <F as Poseidon2>::external_matrix(&mut state);
+            round_ctr += 1;
+        }
+
+        for i in 0..WIDTH {
+            yield_constr.one(state[i] - vars.local_wires[Self::wire_output(i)]);
+        }
+    }
+
+    fn eval_unfiltered_circuit(
+        &self,
+        builder: &mut CircuitBuilder<F, D>,
+        vars: EvaluationTargets<D>,
+    ) -> Vec<ExtensionTarget<D>> {
+        let mut constraints = Vec::with_capacity(self.num_constraints());
+
+        // Assert that `swap` is binary.
+        let swap = vars.local_wires[Self::WIRE_SWAP];
+        constraints.push(builder.mul_sub_extension(swap, swap, swap));
+
+        // Assert that each delta wire is set properly: `delta_i = swap * (rhs - lhs)`.
+        for i in 0..4 {
+            let input_lhs = vars.local_wires[Self::wire_input(i)];
+            let input_rhs = vars.local_wires[Self::wire_input(i + 4)];
+            let delta_i = vars.local_wires[Self::wire_delta(i)];
+            let diff = builder.sub_extension(input_rhs, input_lhs);
+            constraints.push(builder.mul_sub_extension(swap, diff, delta_i));
+        }
+
+        // Compute the possibly-swapped input layer.
+        let mut state = [builder.zero_extension(); WIDTH];
+        for i in 0..4 {
+            let delta_i = vars.local_wires[Self::wire_delta(i)];
+            let input_lhs = vars.local_wires[Self::wire_input(i)];
+            let input_rhs = vars.local_wires[Self::wire_input(i + 4)];
+            state[i] = builder.add_extension(input_lhs, delta_i);
+            state[i + 4] = builder.sub_extension(input_rhs, delta_i);
+        }
+        for i in 8..WIDTH {
+            state[i] = vars.local_wires[Self::wire_input(i)];
+        }
+
+        let mut round_ctr = 0;
+
+        // First external matrix
+        <F as Poseidon2>::external_matrix_circuit(builder, &mut state);
+
+        // First set of full rounds.
+        for r in 0..poseidon2::HALF_N_FULL_ROUNDS {
+            <F as Poseidon2>::constant_layer_circuit(builder, &mut state, round_ctr);
+            if r != 0 {
+                for i in 0..WIDTH {
+                    let sbox_in = vars.local_wires[Self::wire_full_sbox_0(r, i)];
+                    constraints.push(builder.sub_extension(state[i], sbox_in));
+                    state[i] = sbox_in;
+                }
+            }
+            <F as Poseidon2>::sbox_layer_circuit(builder, &mut state);
+            <F as Poseidon2>::external_matrix_circuit(builder, &mut state);
+            round_ctr += 1;
+        }
+
+        // Partial rounds.
+        let mut constant_counter = poseidon2::HALF_N_FULL_ROUNDS * WIDTH;
+        for r in 0..(poseidon2::N_PARTIAL_ROUNDS) {
+            let c = poseidon2::ALL_ROUND_CONSTANTS[constant_counter];
+            let c = F::Extension::from_canonical_u64(c);
+            let c = builder.constant_extension(c);
+            state[0] = builder.add_extension(state[0], c);
+            constant_counter += WIDTH;
+            let sbox_in = vars.local_wires[Self::wire_partial_sbox(r)];
+            constraints.push(builder.sub_extension(state[0], sbox_in));
+            state[0] = <F as Poseidon2>::sbox_monomial_circuit(builder, sbox_in);
+            <F as Poseidon2>::internal_matrix_circuit(builder, &mut state);
+        }
+        round_ctr += poseidon2::N_PARTIAL_ROUNDS;
+
+        // Second set of full rounds.
+        for r in 0..poseidon2::HALF_N_FULL_ROUNDS {
+            <F as Poseidon2>::constant_layer_circuit(builder, &mut state, round_ctr);
+            for i in 0..WIDTH {
+                let sbox_in = vars.local_wires[Self::wire_full_sbox_1(r, i)];
+                constraints.push(builder.sub_extension(state[i], sbox_in));
+                state[i] = sbox_in;
+            }
+            <F as Poseidon2>::sbox_layer_circuit(builder, &mut state);
+            <F as Poseidon2>::external_matrix_circuit(builder, &mut state);
+            round_ctr += 1;
+        }
+
+        for i in 0..WIDTH {
+            constraints
+                .push(builder.sub_extension(state[i], vars.local_wires[Self::wire_output(i)]));
+        }
+
+        constraints
+    }
+
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<WitnessGeneratorRef<F, D>> {
+        let gen = Poseidon2Generator::<F, D> {
+            row,
+            _phantom: PhantomData,
+        };
+        vec![WitnessGeneratorRef::new(gen.adapter())]
+    }
+
+    fn num_wires(&self) -> usize {
+        Self::end()
+    }
+
+    fn num_constants(&self) -> usize {
+        0
+    }
+
+    fn degree(&self) -> usize {
+        7
+    }
+
+    fn num_constraints(&self) -> usize {
+        WIDTH * (poseidon2::N_FULL_ROUNDS_TOTAL - 1) + poseidon2::N_PARTIAL_ROUNDS + WIDTH + 1 + 4
+    }
+
+    fn serialize(&self, dst: &mut Vec<u8>, common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        Ok(())
+    }
+
+    fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Poseidon2Gate::new())
+    }
+}
+
+#[derive(Debug)]
+struct Poseidon2Generator<F: RichField + Extendable<D> + Poseidon2, const D: usize> {
+    row: usize,
+    _phantom: PhantomData<F>,
+}
+
+impl<F: RichField + Extendable<D> + Poseidon2, const D: usize> SimpleGenerator<F, D>
+    for Poseidon2Generator<F, D>
+{
+    fn dependencies(&self) -> Vec<Target> {
+        (0..WIDTH)
+            .map(|i| Poseidon2Gate::<F, D>::wire_input(i))
+            .chain(Some(Poseidon2Gate::<F, D>::WIRE_SWAP))
+            .map(|column| Target::wire(self.row, column))
+            .collect()
+    }
+
+    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+        let local_wire = |column| Wire {
+            row: self.row,
+            column,
+        };
+
+        let mut state = (0..WIDTH)
+            .map(|i| witness.get_wire(local_wire(Poseidon2Gate::<F, D>::wire_input(i))))
+            .collect::<Vec<_>>();
+
+        let swap_value = witness.get_wire(local_wire(Poseidon2Gate::<F, D>::WIRE_SWAP));
+        debug_assert!(swap_value == F::ZERO || swap_value == F::ONE);
+
+        for i in 0..4 {
+            let delta_i = swap_value * (state[i + 4] - state[i]);
+            out_buffer.set_wire(local_wire(Poseidon2Gate::<F, D>::wire_delta(i)), delta_i);
+        }
+
+        if swap_value == F::ONE {
+            for i in 0..4 {
+                state.swap(i, 4 + i);
+            }
+        }
+
+        let mut state: [F; WIDTH] = state.try_into().unwrap();
+        let mut round_ctr = 0;
+
+        // First external matrix
+        <F as Poseidon2>::external_matrix_field(&mut state);
+
+        for r in 0..poseidon2::HALF_N_FULL_ROUNDS {
+            <F as Poseidon2>::constant_layer_field(&mut state, round_ctr);
+            if r != 0 {
+                for i in 0..WIDTH {
+                    out_buffer.set_wire(
+                        local_wire(Poseidon2Gate::<F, D>::wire_full_sbox_0(r, i)),
+                        state[i],
+                    );
+                }
+            }
+            <F as Poseidon2>::sbox_layer_field(&mut state);
+            <F as Poseidon2>::external_matrix_field(&mut state);
+            round_ctr += 1;
+        }
+
+        let mut constant_counter = poseidon2::HALF_N_FULL_ROUNDS * WIDTH;
+        for r in 0..(poseidon2::N_PARTIAL_ROUNDS) {
+            state[0] += F::from_canonical_u64(poseidon2::ALL_ROUND_CONSTANTS[constant_counter]);
+            constant_counter += WIDTH;
+            out_buffer.set_wire(
+                local_wire(Poseidon2Gate::<F, D>::wire_partial_sbox(r)),
+                state[0],
+            );
+            state[0] = <F as Poseidon2>::sbox_monomial(state[0]);
+            <F as Poseidon2>::internal_matrix_field(&mut state);
+        }
+        round_ctr += poseidon2::N_PARTIAL_ROUNDS;
+
+        for r in 0..poseidon2::HALF_N_FULL_ROUNDS {
+            <F as Poseidon2>::constant_layer_field(&mut state, round_ctr);
+            for i in 0..WIDTH {
+                out_buffer.set_wire(
+                    local_wire(Poseidon2Gate::<F, D>::wire_full_sbox_1(r, i)),
+                    state[i],
+                );
+            }
+            <F as Poseidon2>::sbox_layer_field(&mut state);
+            <F as Poseidon2>::external_matrix_field(&mut state);
+            round_ctr += 1;
+        }
+
+        for i in 0..WIDTH {
+            out_buffer.set_wire(local_wire(Poseidon2Gate::<F, D>::wire_output(i)), state[i]);
+        }
+    }
+
+    fn id(&self) -> String {
+        "Poseidon2Generator".to_string()
+    }
+
+    fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        dst.write_usize(self.row)
+    }
+
+    fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self>
+    where
+        Self: Sized,
+    {
+        let row = src.read_usize()?;
+        Ok(Self {
+            row,
+            _phantom: PhantomData,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use plonky2::field::goldilocks_field::GoldilocksField;
+    use plonky2::field::types::Field;
+    use plonky2::gates::gate_testing::{test_eval_fns, test_low_degree};
+    use plonky2::iop::target::Target;
+    use plonky2::iop::wire::Wire;
+    use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+    use plonky2::plonk::circuit_builder::CircuitBuilder;
+    use plonky2::plonk::circuit_data::CircuitConfig;
+    use plonky2::plonk::config::GenericConfig;
+
+    use super::Poseidon2Gate;
+    use crate::poseidon2_goldilock::Poseidon2GoldilocksConfig;
+    use crate::poseidon2_hash::{Poseidon2, WIDTH};
+
+    #[test]
+    fn wire_indices() {
+        type F = GoldilocksField;
+        type Gate = Poseidon2Gate<F, 4>;
+
+        assert_eq!(Gate::wire_input(0), 0);
+        assert_eq!(Gate::wire_input(11), 11);
+        assert_eq!(Gate::wire_output(0), 12);
+        assert_eq!(Gate::wire_output(11), 23);
+        assert_eq!(Gate::WIRE_SWAP, 24);
+        assert_eq!(Gate::wire_delta(0), 25);
+        assert_eq!(Gate::wire_delta(3), 28);
+        assert_eq!(Gate::wire_full_sbox_0(1, 0), 29);
+        assert_eq!(Gate::wire_full_sbox_0(3, 0), 53);
+        assert_eq!(Gate::wire_full_sbox_0(3, 11), 64);
+        assert_eq!(Gate::wire_partial_sbox(0), 65);
+        assert_eq!(Gate::wire_partial_sbox(21), 86);
+        assert_eq!(Gate::wire_full_sbox_1(0, 0), 87);
+        assert_eq!(Gate::wire_full_sbox_1(3, 0), 123);
+        assert_eq!(Gate::wire_full_sbox_1(3, 11), 134);
+    }
+
+    #[test]
+    fn generated_output() {
+        const D: usize = 2;
+        type C = Poseidon2GoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        let config = CircuitConfig {
+            num_wires: 143,
+            ..CircuitConfig::standard_recursion_config()
+        };
+        let mut builder = CircuitBuilder::new(config);
+        type Gate = Poseidon2Gate<F, D>;
+        let gate = Gate::new();
+        let row = builder.add_gate(gate, vec![]);
+        for i in 0..WIDTH {
+            builder.register_public_input(Target::wire(row, Gate::wire_output(i)));
+        }
+        let circuit = builder.build_prover::<C>();
+
+        let permutation_inputs = (0..WIDTH).map(F::from_canonical_usize).collect::<Vec<_>>();
+
+        let mut inputs = PartialWitness::new();
+        inputs.set_wire(
+            Wire {
+                row,
+                column: Gate::WIRE_SWAP,
+            },
+            F::ZERO,
+        );
+        for i in 0..WIDTH {
+            inputs.set_wire(
+                Wire {
+                    row,
+                    column: Gate::wire_input(i),
+                },
+                permutation_inputs[i],
+            );
+        }
+
+        let proof = circuit.prove(inputs).unwrap();
+
+        let expected_outputs: [F; WIDTH] = F::poseidon2(permutation_inputs.try_into().unwrap());
+        expected_outputs
+            .iter()
+            .zip(proof.public_inputs.iter())
+            .for_each(|(expected_out, out)| assert_eq!(expected_out, out));
+    }
+
+    #[test]
+    fn low_degree() {
+        type F = GoldilocksField;
+        let gate = Poseidon2Gate::<F, 4>::new();
+        test_low_degree(gate)
+    }
+
+    #[test]
+    fn eval_fns() -> Result<()> {
+        const D: usize = 2;
+        type C = Poseidon2GoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+        let gate = Poseidon2Gate::<F, 2>::new();
+        test_eval_fns::<F, C, _, D>(gate)
+    }
+}

--- a/poseidon2_plonky2/src/poseidon2_gate.rs
+++ b/poseidon2_plonky2/src/poseidon2_gate.rs
@@ -386,7 +386,7 @@ impl<F: RichField + Extendable<D> + Poseidon2, const D: usize> Gate<F, D> for Po
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Poseidon2Generator<F: RichField + Extendable<D> + Poseidon2, const D: usize> {
     row: usize,
     _phantom: PhantomData<F>,

--- a/poseidon2_plonky2/src/poseidon2_gate.rs
+++ b/poseidon2_plonky2/src/poseidon2_gate.rs
@@ -386,8 +386,8 @@ impl<F: RichField + Extendable<D> + Poseidon2, const D: usize> Gate<F, D> for Po
     }
 }
 
-#[derive(Debug)]
-struct Poseidon2Generator<F: RichField + Extendable<D> + Poseidon2, const D: usize> {
+#[derive(Debug, Clone)]
+pub struct Poseidon2Generator<F: RichField + Extendable<D> + Poseidon2, const D: usize> {
     row: usize,
     _phantom: PhantomData<F>,
 }

--- a/poseidon2_plonky2/src/poseidon2_goldilock.rs
+++ b/poseidon2_plonky2/src/poseidon2_goldilock.rs
@@ -20,7 +20,7 @@ impl Poseidon2 for GoldilocksField {
     #[inline(always)]
     fn sbox_layer(state: &mut [Self; 12]) {
          unsafe {
-             crate::hash::arch::aarch64::poseidon_goldilocks_neon::sbox_layer(state);
+             plonky2::hash::arch::aarch64::poseidon_goldilocks_neon::sbox_layer(state);
          }
     }
 }

--- a/poseidon2_plonky2/src/poseidon2_goldilock.rs
+++ b/poseidon2_plonky2/src/poseidon2_goldilock.rs
@@ -1,0 +1,170 @@
+//! Implementations for Poseidon2 over Goldilocks field of widths 12.
+
+use plonky2::field::extension::quadratic::QuadraticExtension;
+use plonky2::field::goldilocks_field::GoldilocksField;
+use plonky2::plonk::config::GenericConfig;
+
+use crate::poseidon2_hash::{Poseidon2, Poseidon2Hash, WIDTH};
+
+#[rustfmt::skip]
+impl Poseidon2 for GoldilocksField {
+    // We only need INTERNAL_MATRIX_DIAG_M_1 here, specifying the diagonal - 1 of the internal matrix
+
+    const INTERNAL_MATRIX_DIAG_M_1: [u64; WIDTH]  = [
+        0xcf6f77ac16722af9, 0x3fd4c0d74672aebc, 0x9b72bf1c1c3d08a8, 0xe4940f84b71e4ac2,
+        0x61b27b077118bc72, 0x2efd8379b8e661e2, 0x858edcf353df0341, 0x2d9c20affb5c4516,
+        0x5120143f0695defb, 0x62fc898ae34a5c5b, 0xa3d9560c99123ed2, 0x98fd739d8e7fc933,
+    ];
+
+    #[cfg(all(target_arch="aarch64", target_feature="neon"))]
+    #[inline(always)]
+    fn sbox_layer(state: &mut [Self; 12]) {
+         unsafe {
+             crate::hash::arch::aarch64::poseidon_goldilocks_neon::sbox_layer(state);
+         }
+    }
+}
+
+/// Configuration using Poseidon2 over the Goldilocks field.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Poseidon2GoldilocksConfig;
+impl GenericConfig<2> for Poseidon2GoldilocksConfig {
+    type F = GoldilocksField;
+    type FE = QuadraticExtension<Self::F>;
+    type Hasher = Poseidon2Hash;
+    type InnerHasher = Poseidon2Hash;
+}
+
+#[cfg(test)]
+mod tests {
+    use plonky2::field::extension::Extendable;
+    use plonky2::field::goldilocks_field::GoldilocksField as F;
+    use plonky2::hash::hash_types::RichField;
+    use plonky2::hash::poseidon::PoseidonHash;
+    use plonky2::plonk::circuit_data::CircuitConfig;
+    use plonky2::plonk::config::{
+        AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig,
+    };
+    use rstest::rstest;
+    use serial_test::serial;
+
+    use crate::poseidon2_goldilock::Poseidon2GoldilocksConfig;
+    use crate::poseidon2_hash::test_helpers::{
+        check_test_vectors, prove_circuit_with_poseidon_hash, recursive_proof,
+    };
+    use crate::poseidon2_hash::{Poseidon2, Poseidon2Hash};
+
+    const D: usize = 2;
+
+    #[test]
+    fn test_vectors() {
+        // Test inputs are:
+        // 1. range 0..WIDTH
+
+        #[rustfmt::skip]
+            let test_vectors12: Vec<([u64; 12], [u64; 12])> = vec![
+            ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, ],
+             [0xed3dbcc4ff1e8d33, 0xfb85eac6ac91a150, 0xd41e1e237ed3e2ef, 0x5e289bf0a4c11897,
+                 0x4398b20f93e3ba6b, 0x5659a48ffaf2901d, 0xe44d81e89a88f8ae, 0x08efdb285f8c3dbc,
+                 0x294ab7503297850e, 0xa11c61f4870b9904, 0xa6855c112cc08968, 0x17c6d53d2fb3e8c1, ]),
+        ];
+
+        check_test_vectors::<F>(test_vectors12);
+    }
+
+    #[test]
+    fn test_circuit_with_poseidon2() {
+        let (cd, proof) = prove_circuit_with_poseidon_hash::<_, Poseidon2GoldilocksConfig, D, _>(
+            CircuitConfig::standard_recursion_config(),
+            1024,
+            Poseidon2Hash,
+            false,
+        )
+        .unwrap();
+
+        cd.verify(proof).unwrap();
+    }
+
+    #[ignore]
+    #[rstest]
+    #[case::poseidon(PoseidonGoldilocksConfig{})]
+    #[case::poseidon2(Poseidon2GoldilocksConfig{})]
+    #[serial]
+    fn compare_proof_generation_with_poseidon<
+        F: RichField + Extendable<D> + Poseidon2,
+        const D: usize,
+        C: GenericConfig<D, F = F>,
+    >(
+        #[case] _c: C,
+    ) {
+        let (cd, proof) = prove_circuit_with_poseidon_hash::<_, C, D, _>(
+            CircuitConfig::standard_recursion_config(),
+            4096,
+            Poseidon2Hash,
+            true,
+        )
+        .unwrap();
+
+        cd.verify(proof).unwrap();
+    }
+
+    #[ignore]
+    #[rstest]
+    #[case::poseidon(PoseidonGoldilocksConfig, PoseidonHash{})]
+    #[case::poseidon2(PoseidonGoldilocksConfig, Poseidon2Hash{})]
+    #[serial]
+    fn compare_circuits_with_poseidon<
+        F: RichField + Extendable<D> + Poseidon2,
+        const D: usize,
+        C: GenericConfig<D, F = F>,
+        H: Hasher<F> + AlgebraicHasher<F>,
+    >(
+        #[case] _conf: C,
+        #[case] hasher: H,
+    ) {
+        let (cd, proof) = prove_circuit_with_poseidon_hash::<_, C, D, _>(
+            CircuitConfig::standard_recursion_config(),
+            4096,
+            hasher,
+            true,
+        )
+        .unwrap();
+
+        cd.verify(proof).unwrap();
+    }
+
+    #[rstest]
+    #[serial]
+    fn test_recursive_circuit_with_poseidon2<
+        F: RichField + Poseidon2 + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        InnerC: GenericConfig<D, F = F>,
+        const D: usize,
+    >(
+        #[values(PoseidonGoldilocksConfig{}, Poseidon2GoldilocksConfig{})] _c: C,
+        #[values(PoseidonGoldilocksConfig{}, Poseidon2GoldilocksConfig{})] _inner: InnerC,
+    ) where
+        InnerC::Hasher: AlgebraicHasher<F>,
+    {
+        let config = CircuitConfig::standard_recursion_config();
+
+        let (cd, proof) = prove_circuit_with_poseidon_hash::<F, InnerC, D, _>(
+            config,
+            1024,
+            Poseidon2Hash {},
+            false,
+        )
+        .unwrap();
+
+        println!("base proof generated");
+
+        let (rec_cd, rec_proof) =
+            recursive_proof::<F, C, InnerC, D>(proof, &cd, &cd.common.config).unwrap();
+
+        println!("recursive proof generated");
+
+        rec_cd.verify(rec_proof).unwrap();
+
+        assert_eq!(rec_cd.common.degree_bits(), 12);
+    }
+}

--- a/poseidon2_plonky2/src/poseidon2_hash.rs
+++ b/poseidon2_plonky2/src/poseidon2_hash.rs
@@ -1,0 +1,802 @@
+//! Implementation of the Poseidon2 hash function and the traits necessary to employ it in Plonky2
+
+use alloc::vec;
+use alloc::vec::Vec;
+use std::fmt::Debug;
+
+use plonky2::field::extension::{Extendable, FieldExtension};
+use plonky2::field::types::{Field, PrimeField64};
+use plonky2::hash::hash_types::{HashOut, RichField};
+use plonky2::hash::hashing::{compress, hash_n_to_hash_no_pad, PlonkyPermutation};
+use plonky2::hash::poseidon::{SPONGE_RATE, SPONGE_WIDTH};
+use plonky2::iop::ext_target::ExtensionTarget;
+use plonky2::iop::target::{BoolTarget, Target};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::config::{AlgebraicHasher, Hasher};
+use unroll::unroll_for_loops;
+
+use crate::poseidon2_gate::Poseidon2Gate;
+
+pub const RATE: usize = SPONGE_RATE;
+pub const WIDTH: usize = SPONGE_WIDTH;
+
+/// The number of full rounds and partial rounds is given by the
+/// calc_round_numbers.py script. They happen to be the same for both
+/// width 8 and width 12 with s-box x^7.
+//
+// NB: Changing any of these values will require regenerating all of
+// the precomputed constant arrays in this file.
+pub const HALF_N_FULL_ROUNDS: usize = 4;
+pub(crate) const N_FULL_ROUNDS_TOTAL: usize = 2 * HALF_N_FULL_ROUNDS;
+pub const N_PARTIAL_ROUNDS: usize = 22;
+pub const N_ROUNDS: usize = N_FULL_ROUNDS_TOTAL + N_PARTIAL_ROUNDS;
+const MAX_WIDTH: usize = 12; // we only have width 8 and 12, and 12 is bigger. :)
+
+// Round constants for Poseidon and Poseidon2 are the same (given a specific instance)
+#[rustfmt::skip]
+pub const ALL_ROUND_CONSTANTS: [u64; MAX_WIDTH * N_ROUNDS]  = [
+    // WARNING: The AVX2 Goldilocks specialization relies on all round constants being in
+    // 0..0xfffeeac900011537. If these constants are randomly regenerated, there is a ~.6% chance
+    // that this condition will no longer hold.
+    0xe034a8785fd284a7, 0xe2463f1ea42e1b80, 0x048742e681ae290a, 0xe4af50ade990154c,
+    0x8b13ffaaf4f78f8a, 0xe3fbead7dccd8d63, 0x631a47705eb92bf8, 0x88fbbb8698548659,
+    0x74cd2003b0f349c9, 0xe16a3df6764a3f5d, 0x57ce63971a71aaa2, 0xdc1f7fd3e7823051,
+    0xbb8423be34c18d7a, 0xf8bc5a2a0c1b3d6d, 0xf1a01bbd6f7123e5, 0xed960a080f5e348b,
+    0x1b9c0c1e87e2390e, 0x18c83caf729a613e, 0x671ab9fe037a72c4, 0x508565f67d4c276a,
+    0x4d2cd8827a482590, 0xa48e11e84dd3500b, 0x825a8c955fc2442b, 0xf573a6ee07cddc68,
+    0x7dd3f19c73a39e0b, 0xcc0f13537a796fa6, 0x1d9006bfaedac57f, 0x4705f69b68b0b7de,
+    0x5b62bfb718bcc57f, 0x879d821770563827, 0x3da5ccb7f8dff0e3, 0xb49d6a706923fc5b,
+    0xb6a0babe883a969d, 0x2984f9b055401960, 0xcd3496f05511d79d, 0x4791da5d63854fc5,
+    0xdb7344d0580a39d4, 0x5aedc4dad1de120a, 0x5e1bdc1fb8e1abf0, 0x3904c09a0e46747c,
+    0xb54a0e23ab85ddcd, 0xc0c3cf05bccbdb3a, 0xb362076a73baf7e9, 0x212c953d81a5d5ba,
+    0x212d4cc965d898bd, 0xdd44ddd0f41509b9, 0x8931329fa67823c0, 0xc65510f4d2a873be,
+    0xe3ecbb6ba1e16211, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x70f5b3266792bbb6, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0xe7560e690634757e, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0xafd0202bc7eaf66e, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x349f4c5871f220fd, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x3697eb3e31529e0d, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x7735d5b0622d9900, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x5f5b58b9cf997668, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x645534b6548af9d9, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x4232d29d91a426a8, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0xb987278aed485d35, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x6dabeef669bb406e, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x35ee78288b749d40, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x6dcd560f14af0fc3, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x71ed3dc007ea6383, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x8b6b51caab7f5b6f, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0xcf2e8cc4181dbfa8, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0xa01d3f1c306f825a, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0xccee646a5d8ddb87, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x70df6f277cbaffeb, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x64ec0a6556b8f45c, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x6f68c9664fda6e37, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+    0x387356e4516fab6f, 0x35310dce33903e67, 0x45f3e5251d30f912, 0x7c97f480ca428f45,
+    0x74d5874c20b50de2, 0xff1d5b7cee3dc67f, 0xa04d5d5ac0ff3de9, 0x1cefb5eb7d24580e,
+    0xf685e1bfcc0104ad, 0x6204dd95db22ead4, 0x8265c6c57c73c440, 0x4f708ab0b4e1e382,
+    0xcfc60c7a52fbffa7, 0x9c0c1951d8910306, 0x4d06df27c89819f2, 0x621bdb0e75eca660,
+    0x343adffd079cee57, 0xa760f0e5debde398, 0xe3110fefd97b188a, 0x0ed6584e6b150297,
+    0x2b10e625d0d079c0, 0xefa493442057264f, 0xebcfaa7b3f26a2b6, 0xf36bcda28e343e2a,
+    0xa1183cb63b67aa9e, 0x40f3e415d5e5b0ba, 0xc51fc2367eff7b15, 0xe07fe5f3aebc649f,
+    0xc9cb2be56968e8aa, 0x648600db69078a0e, 0x4e9135ab1256edb9, 0x00382c73435556c2,
+    0x1d78cafac9150ddf, 0xb8df60ab6215a233, 0xa7a65ba31f8fcd9a, 0x907d436dd964006b,
+    0x3bdf7fd528633b97, 0x265adb359c0cc0f8, 0xf16cfc4034b39614, 0x71f0751b08fa0947,
+    0x3165eda4b5403a37, 0xca30fc5680467e46, 0x4c743354d37777c5, 0x3d1f0a4e6bba4a09,
+    0xc0c2e289afa75181, 0x1e4fa2ad948978b7, 0x2a226a127a0bb26a, 0xe61738a70357ce76,
+];
+
+// Applying cheap 4x4 MDS matrix to each 4-element part of the state
+// The matrix in this case is:
+// M_4 =
+// [5   7   1   3]
+// [4   6   1   1]
+// [1   3   5   7]
+// [1   1   4   6]
+// The computation is shown in more detail in https://tosc.iacr.org/index.php/ToSC/article/view/888/839, Figure 13 (M_{4,4}^{8,4} with alpha = 2)
+#[inline(always)]
+fn matrix_mul_block(x: &mut [u64]) {
+    let mut t_2 = x[1];
+    let mut t_3 = x[3];
+    let t_0 = x[0] + t_2;
+    let t_1 = x[2] + t_3;
+    t_2 = (t_2 << 1) + t_1;
+    t_3 = (t_3 << 1) + t_0;
+    let t_4 = (t_1 << 2) + t_3;
+    let t_5 = (t_0 << 2) + t_2;
+    let t_6 = t_3 + t_5;
+    let t_7 = t_2 + t_4;
+    x[0] = t_6;
+    x[1] = t_5;
+    x[2] = t_7;
+    x[3] = t_4;
+}
+
+#[inline(always)]
+#[unroll_for_loops]
+fn combine_m4_prods(x: &mut [u64], s: [u64; 4]) {
+    for i in 0..4 {
+        x[i] += s[i];
+    }
+}
+
+const T4: usize = WIDTH / 4;
+
+// Apply external matrix to a state vector with at most 32 bits elements.
+// This is employed to compute product with external matrix employing only native u64 integer
+// arithmetic for efficiency
+#[inline(always)]
+#[unroll_for_loops]
+fn external_matrix_with_u64_arithmetic(x: &mut [u64; WIDTH]) {
+    for i in 0..T4 {
+        matrix_mul_block(&mut x[i * 4..(i + 1) * 4]);
+    }
+
+    // Applying second cheap matrix
+    // This completes the multiplication by
+    // M_E =
+    // [2*M_4    M_4    M_4]
+    // [  M_4  2*M_4    M_4]
+    // [  M_4    M_4  2*M_4]
+    // using the results with M_4 obtained above
+
+    // compute vector to be later used to combine M_4 multiplication results with current state x;
+    // this operation is performed without loops for efficiency
+    debug_assert_eq!(T4, 3);
+    let s0 = x[0] + x[4] + x[8];
+    let s1 = x[1] + x[5] + x[9];
+    let s2 = x[2] + x[6] + x[10];
+    let s3 = x[3] + x[7] + x[11];
+    let s = [s0, s1, s2, s3];
+
+    for i in 0..T4 {
+        combine_m4_prods(&mut x[i * 4..(i + 1) * 4], s);
+    }
+}
+
+pub trait Poseidon2: PrimeField64 {
+    /// Total number of round constants required: width of the input
+    /// times number of rounds.
+    const N_ROUND_CONSTANTS: usize = WIDTH * N_ROUNDS;
+
+    /// We only need INTERNAL_MATRIX_DIAG_M_1 here, specifying the diagonal - 1 of the internal matrix
+    const INTERNAL_MATRIX_DIAG_M_1: [u64; WIDTH];
+
+    /// Compute the product between the state vector and the matrix employed in full rounds of
+    /// the permutation
+    #[inline(always)]
+    #[unroll_for_loops]
+    fn external_matrix(state: &mut [Self; WIDTH]) {
+        let mut state_l = [0u64; WIDTH];
+        let mut state_h = [0u64; WIDTH];
+        for i in 0..WIDTH {
+            let state_u64 = state[i].to_noncanonical_u64();
+            state_h[i] = state_u64 >> 32;
+            state_l[i] = (state_u64 as u32) as u64;
+        }
+        external_matrix_with_u64_arithmetic(&mut state_l);
+        external_matrix_with_u64_arithmetic(&mut state_h);
+
+        for i in 0..WIDTH {
+            let (state_u64, carry) = state_l[i].overflowing_add(state_h[i] << 32);
+            state[i] =
+                Self::from_noncanonical_u96((state_u64, (state_h[i] >> 32) as u32 + carry as u32));
+        }
+    }
+
+    /// Same as `external_matrix` for field extensions of `Self`.
+    fn external_matrix_field<F: FieldExtension<D, BaseField = Self>, const D: usize>(
+        state: &mut [F; WIDTH],
+    ) {
+        // Applying cheap 4x4 MDS matrix to each 4-element part of the state
+        let t4 = WIDTH / 4;
+        for i in 0..t4 {
+            let start_index = i * 4;
+            let mut t_0 = state[start_index];
+            t_0 += state[start_index + 1];
+            let mut t_1 = state[start_index + 2];
+            t_1 += state[start_index + 3];
+            let mut t_2 = state[start_index + 1];
+            t_2 = t_2 + t_2;
+            t_2 += t_1;
+            let mut t_3 = state[start_index + 3];
+            t_3 = t_3 + t_3;
+            t_3 += t_0;
+            let mut t_4 = t_1;
+            t_4 = F::from_canonical_u64(4) * t_4;
+            t_4 += t_3;
+            let mut t_5 = t_0;
+            t_5 = F::from_canonical_u64(4) * t_5;
+            t_5 += t_2;
+            let mut t_6 = t_3;
+            t_6 += t_5;
+            let mut t_7 = t_2;
+            t_7 += t_4;
+            state[start_index] = t_6;
+            state[start_index + 1] = t_5;
+            state[start_index + 2] = t_7;
+            state[start_index + 3] = t_4;
+        }
+
+        // Applying second cheap matrix
+        let mut stored = [F::ZERO; 4];
+        for l in 0..4 {
+            stored[l] = state[l];
+            for j in 1..t4 {
+                stored[l] += state[4 * j + l];
+            }
+        }
+        for i in 0..WIDTH {
+            state[i] += stored[i % 4];
+        }
+    }
+
+    /// Recursive version of `external_matrix`.
+    fn external_matrix_circuit<const D: usize>(
+        builder: &mut CircuitBuilder<Self, D>,
+        state: &mut [ExtensionTarget<D>; WIDTH],
+    ) where
+        Self: RichField + Extendable<D>,
+    {
+        // In contrast to the Poseidon circuit, we *may not need* PoseidonMdsGate, because the number of constraints will fit regardless
+        // Check!
+        let four = Self::from_canonical_u64(0x4);
+        // let four = builder.constant_extension(Self::Extension::from_canonical_u64(0x4));
+
+        // Applying cheap 4x4 MDS matrix to each 4-element part of the state
+        let t4 = WIDTH / 4;
+        for i in 0..t4 {
+            let start_index = i * 4;
+            let mut t_0 = state[start_index];
+            t_0 = builder.add_extension(t_0, state[start_index + 1]);
+            let mut t_1 = state[start_index + 2];
+            t_1 = builder.add_extension(t_1, state[start_index + 3]);
+            let mut t_2 = state[start_index + 1];
+            t_2 = builder.add_extension(t_2, t_2); // Double
+            t_2 = builder.add_extension(t_2, t_1);
+            let mut t_3 = state[start_index + 3];
+            t_3 = builder.add_extension(t_3, t_3); // Double
+            t_3 = builder.add_extension(t_3, t_0);
+            let mut t_4 = t_1;
+            t_4 = builder.mul_const_extension(four, t_4); // times 4
+            t_4 = builder.add_extension(t_4, t_3);
+            let mut t_5 = t_0;
+            t_5 = builder.mul_const_extension(four, t_5); // times 4
+            t_5 = builder.add_extension(t_5, t_2);
+            let mut t_6 = t_3;
+            t_6 = builder.add_extension(t_6, t_5);
+            let mut t_7 = t_2;
+            t_7 = builder.add_extension(t_7, t_4);
+            state[start_index] = t_6;
+            state[start_index + 1] = t_5;
+            state[start_index + 2] = t_7;
+            state[start_index + 3] = t_4;
+        }
+
+        // Applying second cheap matrix
+        let mut stored = [builder.zero_extension(); 4];
+        for l in 0..4 {
+            stored[l] = state[l];
+            for j in 1..t4 {
+                stored[l] = builder.add_extension(stored[l], state[4 * j + l]);
+            }
+        }
+        for i in 0..WIDTH {
+            state[i] = builder.add_extension(state[i], stored[i % 4]);
+        }
+    }
+
+    /// Compute the product between the state vector and the matrix employed in partial rounds of
+    /// the permutation
+    #[inline(always)]
+    #[unroll_for_loops]
+    fn internal_matrix(state: &mut [Self; WIDTH]) {
+        // This computes the mutliplication with the matrix
+        // M_I =
+        // [r_1     1   1   ...     1]
+        // [  1   r_2   1   ...     1]
+        // ...
+        // [  1     1   1   ...   r_t]
+        // for pseudo-random values r_1, r_2, ..., r_t. Note that for efficiency in Self::INTERNAL_MATRIX_DIAG_M_1 only r_1 - 1, r_2 - 1, ..., r_t - 1 are stored
+        // Compute input sum
+        let f_sum = Self::from_noncanonical_u128(
+            state
+                .iter()
+                .fold(0u128, |sum, el| sum + el.to_noncanonical_u64() as u128),
+        );
+        // Add sum + diag entry * element to each element
+        for i in 0..WIDTH {
+            state[i] *= Self::from_canonical_u64(Self::INTERNAL_MATRIX_DIAG_M_1[i]);
+            state[i] += f_sum;
+        }
+    }
+
+    /// Same as `internal_matrix` for field extensions of `Self`.
+    fn internal_matrix_field<F: FieldExtension<D, BaseField = Self>, const D: usize>(
+        state: &mut [F; WIDTH],
+    ) {
+        // Compute input sum
+        let sum = state.iter().fold(F::ZERO, |sum, el| sum + *el);
+        // Add sum + diag entry * element to each element
+        for i in 0..state.len() {
+            state[i] *= F::from_canonical_u64(Self::INTERNAL_MATRIX_DIAG_M_1[i]);
+            state[i] += sum;
+        }
+    }
+
+    /// Recursive version of `internal_matrix`.
+    fn internal_matrix_circuit<const D: usize>(
+        builder: &mut CircuitBuilder<Self, D>,
+        state: &mut [ExtensionTarget<D>; WIDTH],
+    ) where
+        Self: RichField + Extendable<D>,
+    {
+        // Compute input sum
+        let mut sum = state[0];
+        for i in 1..state.len() {
+            sum = builder.add_extension(sum, state[i]);
+        }
+        // Add sum + diag entry * element to each element
+        for i in 0..state.len() {
+            // Computes `C * x + y`
+            state[i] = builder.mul_const_add_extension(
+                Self::from_canonical_u64(<Self as Poseidon2>::INTERNAL_MATRIX_DIAG_M_1[i]),
+                state[i],
+                sum,
+            );
+        }
+    }
+
+    /// Add round constant to `state` for round `round_ctr`
+    #[inline(always)]
+    #[unroll_for_loops]
+    fn constant_layer(state: &mut [Self; WIDTH], round_ctr: usize) {
+        for i in 0..12 {
+            if i < WIDTH {
+                let round_constant = ALL_ROUND_CONSTANTS[i + WIDTH * round_ctr];
+                unsafe {
+                    state[i] = state[i].add_canonical_u64(round_constant);
+                }
+            }
+        }
+    }
+
+    /// Same as `constant_layer` for field extensions of `Self`.
+    fn constant_layer_field<F: FieldExtension<D, BaseField = Self>, const D: usize>(
+        state: &mut [F; WIDTH],
+        round_ctr: usize,
+    ) {
+        for i in 0..WIDTH {
+            state[i] += F::from_canonical_u64(ALL_ROUND_CONSTANTS[i + WIDTH * round_ctr]);
+        }
+    }
+
+    /// Recursive version of `constant_layer`.
+    fn constant_layer_circuit<const D: usize>(
+        builder: &mut CircuitBuilder<Self, D>,
+        state: &mut [ExtensionTarget<D>; WIDTH],
+        round_ctr: usize,
+    ) where
+        Self: RichField + Extendable<D>,
+    {
+        for i in 0..WIDTH {
+            let c = ALL_ROUND_CONSTANTS[i + WIDTH * round_ctr];
+            let c = Self::Extension::from_canonical_u64(c);
+            let c = builder.constant_extension(c);
+            state[i] = builder.add_extension(state[i], c);
+        }
+    }
+
+    /// Apply the sbox to a single state element
+    #[inline(always)]
+    fn sbox_monomial<F: FieldExtension<D, BaseField = Self>, const D: usize>(x: F) -> F {
+        // x |--> x^7
+        let x2 = x.square();
+        let x4 = x2.square();
+        let x3 = x * x2;
+        x3 * x4
+    }
+
+    /// Recursive version of `sbox_monomial`.
+    fn sbox_monomial_circuit<const D: usize>(
+        builder: &mut CircuitBuilder<Self, D>,
+        x: ExtensionTarget<D>,
+    ) -> ExtensionTarget<D>
+    where
+        Self: RichField + Extendable<D>,
+    {
+        // x |--> x^7
+        builder.exp_u64_extension(x, 7)
+    }
+
+    /// Apply the sbox-layer to the whole state of the permutation
+    #[inline(always)]
+    #[unroll_for_loops]
+    fn sbox_layer(state: &mut [Self; WIDTH]) {
+        for i in 0..12 {
+            if i < WIDTH {
+                state[i] = Self::sbox_monomial(state[i]);
+            }
+        }
+    }
+
+    /// Same as `sbox_layer` for field extensions of `Self`.
+    fn sbox_layer_field<F: FieldExtension<D, BaseField = Self>, const D: usize>(
+        state: &mut [F; WIDTH],
+    ) {
+        for i in 0..WIDTH {
+            state[i] = Self::sbox_monomial(state[i]);
+        }
+    }
+
+    /// Recursive version of `sbox_layer`.
+    fn sbox_layer_circuit<const D: usize>(
+        builder: &mut CircuitBuilder<Self, D>,
+        state: &mut [ExtensionTarget<D>; WIDTH],
+    ) where
+        Self: RichField + Extendable<D>,
+    {
+        for i in 0..WIDTH {
+            state[i] = <Self as Poseidon2>::sbox_monomial_circuit(builder, state[i]);
+        }
+    }
+
+    /// Apply half of the overall full rounds of the permutation. It can be employed to perform
+    /// both the first and the second half of the full rounds, depending on the value of `round_ctr`
+    #[inline]
+    fn full_rounds(state: &mut [Self; WIDTH], round_ctr: &mut usize) {
+        for _ in 0..HALF_N_FULL_ROUNDS {
+            Self::constant_layer(state, *round_ctr);
+            Self::sbox_layer(state);
+            Self::external_matrix(state);
+            *round_ctr += 1;
+        }
+    }
+
+    /// Apply the partial rounds of the permutation
+    #[inline]
+    fn partial_rounds(state: &mut [Self; WIDTH], round_ctr: &mut usize) {
+        let mut constant_counter = HALF_N_FULL_ROUNDS * WIDTH;
+        for _ in 0..N_PARTIAL_ROUNDS {
+            unsafe {
+                state[0] = state[0].add_canonical_u64(ALL_ROUND_CONSTANTS[constant_counter]);
+                constant_counter += WIDTH;
+            }
+            state[0] = Self::sbox_monomial(state[0]);
+            Self::internal_matrix(state);
+        }
+        *round_ctr += N_PARTIAL_ROUNDS;
+    }
+    /// Apply the entire Poseidon2 permutation to `input`
+    ///
+    /// ```rust
+    /// use plonky2::field::goldilocks_field::GoldilocksField as F;
+    /// use plonky2::field::types::Sample;
+    /// use poseidon2_plonky2::poseidon2_hash::Poseidon2;
+    ///
+    /// let output = F::poseidon2(F::rand_array());
+    /// ```
+    #[inline]
+    fn poseidon2(input: [Self; WIDTH]) -> [Self; WIDTH] {
+        let mut state = input;
+        let mut round_ctr = 0;
+
+        // First external matrix
+        Self::external_matrix(&mut state);
+
+        Self::full_rounds(&mut state, &mut round_ctr);
+        Self::partial_rounds(&mut state, &mut round_ctr);
+        Self::full_rounds(&mut state, &mut round_ctr);
+        debug_assert_eq!(round_ctr, N_ROUNDS);
+
+        state
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+/// Poseidon2 permutation
+pub struct Poseidon2Permutation<T> {
+    state: [T; WIDTH],
+}
+
+impl<T> AsRef<[T]> for Poseidon2Permutation<T> {
+    fn as_ref(&self) -> &[T] {
+        &self.state
+    }
+}
+
+trait Permuter: Sized {
+    fn permute(input: [Self; WIDTH]) -> [Self; WIDTH];
+}
+
+impl<F: Poseidon2> Permuter for F {
+    fn permute(input: [Self; WIDTH]) -> [Self; WIDTH] {
+        <F as Poseidon2>::poseidon2(input)
+    }
+}
+
+impl Permuter for Target {
+    fn permute(_input: [Self; WIDTH]) -> [Self; WIDTH] {
+        panic!("Call `permute_swapped()` instead of `permute()`");
+    }
+}
+
+impl<T: Copy + Debug + Default + Eq + Permuter + Send + Sync> PlonkyPermutation<T>
+    for Poseidon2Permutation<T>
+{
+    const RATE: usize = RATE;
+
+    const WIDTH: usize = WIDTH;
+
+    fn new<I: IntoIterator<Item = T>>(elts: I) -> Self {
+        let mut perm = Self {
+            state: [T::default(); WIDTH],
+        };
+        perm.set_from_iter(elts, 0);
+        perm
+    }
+
+    fn set_elt(&mut self, elt: T, idx: usize) {
+        self.state[idx] = elt;
+    }
+
+    fn set_from_slice(&mut self, elts: &[T], start_idx: usize) {
+        let begin = start_idx;
+        let end = start_idx + elts.len();
+        self.state[begin..end].copy_from_slice(elts);
+    }
+
+    fn set_from_iter<I: IntoIterator<Item = T>>(&mut self, elts: I, start_idx: usize) {
+        for (s, e) in self.state[start_idx..].iter_mut().zip(elts) {
+            *s = e;
+        }
+    }
+
+    fn permute(&mut self) {
+        self.state = T::permute(self.state);
+    }
+
+    fn squeeze(&self) -> &[T] {
+        &self.state[..Self::RATE]
+    }
+}
+
+/// Poseidon2 hash function.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Poseidon2Hash;
+impl<F: RichField + Poseidon2> Hasher<F> for Poseidon2Hash {
+    const HASH_SIZE: usize = 4 * 8;
+    type Hash = HashOut<F>;
+    type Permutation = Poseidon2Permutation<F>;
+
+    fn hash_no_pad(input: &[F]) -> Self::Hash {
+        hash_n_to_hash_no_pad::<F, Self::Permutation>(input)
+    }
+
+    fn two_to_one(left: Self::Hash, right: Self::Hash) -> Self::Hash {
+        compress::<F, Self::Permutation>(left, right)
+    }
+}
+
+impl<F: RichField + Poseidon2> AlgebraicHasher<F> for Poseidon2Hash {
+    fn permute_swapped<const D: usize>(
+        inputs: Self::AlgebraicPermutation,
+        swap: BoolTarget,
+        builder: &mut CircuitBuilder<F, D>,
+    ) -> Self::AlgebraicPermutation
+    where
+        F: RichField + Extendable<D>,
+    {
+        let gate_type = Poseidon2Gate::<F, D>::new();
+        let gate = builder.add_gate(gate_type, vec![]);
+
+        let swap_wire = Poseidon2Gate::<F, D>::WIRE_SWAP;
+        let swap_wire = Target::wire(gate, swap_wire);
+        builder.connect(swap.target, swap_wire);
+
+        // Route input wires.
+        for i in 0..WIDTH {
+            let in_wire = Poseidon2Gate::<F, D>::wire_input(i);
+            let in_wire = Target::wire(gate, in_wire);
+            builder.connect(inputs.as_ref()[i], in_wire);
+        }
+
+        // Collect output wires.
+        Self::AlgebraicPermutation::new(
+            (0..WIDTH).map(|i| Target::wire(gate, Poseidon2Gate::<F, D>::wire_output(i))),
+        )
+    }
+
+    type AlgebraicPermutation = Poseidon2Permutation<Target>;
+}
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use anyhow::Result;
+    use log::{info, Level};
+    use plonky2::field::extension::Extendable;
+    use plonky2::field::types::Field;
+    use plonky2::hash::hash_types::RichField;
+    use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+    use plonky2::plonk::circuit_builder::CircuitBuilder;
+    use plonky2::plonk::circuit_data::{CircuitConfig, CircuitData};
+    use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+    use plonky2::plonk::proof::ProofWithPublicInputs;
+    use plonky2::plonk::prover::prove;
+    use plonky2::util::timing::TimingTree;
+
+    use super::Poseidon2;
+    use crate::poseidon2_hash::WIDTH;
+
+    pub(crate) fn check_test_vectors<F: Field>(test_vectors: Vec<([u64; WIDTH], [u64; WIDTH])>)
+    where
+        F: Poseidon2,
+    {
+        for (input, expected_output) in test_vectors.into_iter() {
+            let mut state = [F::ZERO; WIDTH];
+            for i in 0..WIDTH {
+                state[i] = F::from_canonical_u64(input[i]);
+            }
+            let output = F::poseidon2(state);
+            for i in 0..WIDTH {
+                let ex_output = F::from_canonical_u64(expected_output[i]); // Adjust!
+                assert_eq!(output[i], ex_output);
+            }
+        }
+    }
+
+    pub(crate) fn prove_circuit_with_poseidon_hash<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        const D: usize,
+        H: Hasher<F> + AlgebraicHasher<F>,
+    >(
+        config: CircuitConfig,
+        num_ops: usize,
+        _hasher: H,
+        print_timing: bool,
+    ) -> Result<(CircuitData<F, C, D>, ProofWithPublicInputs<F, C, D>)> {
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let init_t = builder.add_virtual_public_input();
+        let mut res_t = builder.add_virtual_target();
+        builder.connect(init_t, res_t);
+        let hash_targets = (0..WIDTH - 1)
+            .map(|_| builder.add_virtual_target())
+            .collect::<Vec<_>>();
+        for _ in 0..num_ops {
+            res_t = builder.mul(res_t, res_t);
+            let mut to_be_hashed_elements = vec![res_t];
+            to_be_hashed_elements.extend_from_slice(hash_targets.as_slice());
+            res_t = builder.hash_or_noop::<H>(to_be_hashed_elements).elements[0]
+        }
+        let out_t = builder.add_virtual_public_input();
+        let is_eq_t = builder.is_equal(out_t, res_t);
+        builder.assert_one(is_eq_t.target);
+
+        let data = builder.build::<C>();
+
+        let mut pw = PartialWitness::<F>::new();
+        let input = F::rand();
+        pw.set_target(init_t, input);
+
+        let input_hash_elements = hash_targets
+            .iter()
+            .map(|&hash_t| {
+                let elem = F::rand();
+                pw.set_target(hash_t, elem);
+                elem
+            })
+            .collect::<Vec<_>>();
+
+        let mut res = input;
+        for _ in 0..num_ops {
+            res = res.mul(res);
+            let mut to_be_hashed_elements = vec![res];
+            to_be_hashed_elements.extend_from_slice(input_hash_elements.as_slice());
+            res = H::hash_no_pad(to_be_hashed_elements.as_slice()).elements[0]
+        }
+
+        pw.set_target(out_t, res);
+
+        let proof = if print_timing {
+            let mut timing = TimingTree::new("prove", Level::Debug);
+            let proof = prove(&data.prover_only, &data.common, pw, &mut timing)?;
+            timing.print();
+            let proof_bytes = serde_cbor::to_vec(&proof).unwrap();
+            info!("proof size: {}", proof_bytes.len());
+            proof
+        } else {
+            data.prove(pw)?
+        };
+
+        assert_eq!(proof.public_inputs[0], input);
+        assert_eq!(proof.public_inputs[1], res);
+
+        Ok((data, proof))
+    }
+
+    pub(crate) fn recursive_proof<
+        F: RichField + Poseidon2 + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        InnerC: GenericConfig<D, F = F>,
+        const D: usize,
+    >(
+        inner_proof: ProofWithPublicInputs<F, InnerC, D>,
+        inner_cd: &CircuitData<F, InnerC, D>,
+        config: &CircuitConfig,
+    ) -> Result<(CircuitData<F, C, D>, ProofWithPublicInputs<F, C, D>)>
+    where
+        InnerC::Hasher: AlgebraicHasher<F>,
+    {
+        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+        let mut pw = PartialWitness::new();
+        let pt = builder.add_virtual_proof_with_pis(&inner_cd.common);
+        pw.set_proof_with_pis_target(&pt, &inner_proof);
+
+        let inner_data =
+            builder.add_virtual_verifier_data(inner_cd.common.config.fri_config.cap_height);
+        pw.set_cap_target(
+            &inner_data.constants_sigmas_cap,
+            &inner_cd.verifier_only.constants_sigmas_cap,
+        );
+        pw.set_hash_target(
+            inner_data.circuit_digest,
+            inner_cd.verifier_only.circuit_digest,
+        );
+
+        for &pi_t in pt.public_inputs.iter() {
+            let t = builder.add_virtual_public_input();
+            builder.connect(pi_t, t);
+        }
+        builder.verify_proof::<InnerC>(&pt, &inner_data, &inner_cd.common);
+        let data = builder.build::<C>();
+
+        let proof = data.prove(pw)?;
+
+        Ok((data, proof))
+    }
+}


### PR DESCRIPTION
This PR adds a crate providing Poseidon2 hash function implementation, including a Plonky2 gate to be used in circuits.. The implementation is taken from [HorizenLabs](https://github.com/HorizenLabs/plonky2.git), ported to more recent versions of Plonky2 code.

Poseidon2 should give about 15% speed-up in proving time with respect to original Poseidon, while keeping the same in-circuit performance.