### PR TITLE
Fix build for `aarch64`

### DIFF
--- a/plonky2/src/hash/arch/aarch64/mod.rs
+++ b/plonky2/src/hash/arch/aarch64/mod.rs
@@ -1,2 +1,2 @@
 #[cfg(target_feature = "neon")]
-pub(crate) mod poseidon_goldilocks_neon;
+pub mod poseidon_goldilocks_neon;

--- a/plonky2/src/hash/arch/aarch64/poseidon_goldilocks_neon.rs
+++ b/plonky2/src/hash/arch/aarch64/poseidon_goldilocks_neon.rs
@@ -174,7 +174,7 @@ unsafe fn const_layer_full(
 /// Full S-box.
 #[inline(always)]
 #[unroll_for_loops]
-unsafe fn sbox_layer_full(state: [u64; WIDTH]) -> [u64; WIDTH] {
+pub unsafe fn sbox_layer_full(state: [u64; WIDTH]) -> [u64; WIDTH] {
     // This is done in scalar. S-boxes in vector are only slightly slower throughput-wise but have
     // an insane latency (~100 cycles) on the M1.
 

--- a/plonky2/src/hash/arch/mod.rs
+++ b/plonky2/src/hash/arch/mod.rs
@@ -2,4 +2,4 @@
 pub(crate) mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
-pub(crate) mod aarch64;
+pub mod aarch64;

--- a/plonky2/src/hash/mod.rs
+++ b/plonky2/src/hash/mod.rs
@@ -1,7 +1,7 @@
 //! plonky2 hashing logic for in-circuit hashing and Merkle proof verification
 //! as well as specific hash functions implementation.
 
-mod arch;
+pub mod arch;
 pub mod hash_types;
 pub mod hashing;
 pub mod keccak;

--- a/poseidon2_plonky2/Cargo.toml
+++ b/poseidon2_plonky2/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.69"
-plonky2 = "0.2.2"
+plonky2 = { path = "../plonky2" }
 rstest = "0.17.0"
 serial_test = "1.0.0"
 unroll = "0.1.5"
 
 [dev-dependencies]
-criterion = {version = "0.4.0", default-features = false }
+criterion = { version = "0.4.0", default-features = false }
 env_logger = "0.10.0"
 log = "0.4.17"
 rand_chacha = "0.3.1"
@@ -38,4 +38,3 @@ harness = false
 [[bench]]
 name = "recursion"
 harness = false
-


### PR DESCRIPTION
Should we use the local `plonky2` crate?