### PR TITLE
fix: change `Witness` inheritance to `WitnessWrite` for `set_stark_proof_with_pis_target`

### DIFF
--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -14,7 +14,7 @@ use plonky2::hash::hash_types::RichField;
 use plonky2::iop::challenger::RecursiveChallenger;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
-use plonky2::iop::witness::Witness;
+use plonky2::iop::witness::WitnessWrite;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 use plonky2::util::reducing::ReducingFactorTarget;
@@ -328,7 +328,7 @@ pub fn set_stark_proof_with_pis_target<F, C: GenericConfig<D, F = F>, W, const D
 ) where
     F: RichField + Extendable<D>,
     C::Hasher: AlgebraicHasher<F>,
-    W: Witness<F>,
+    W: WitnessWrite<F>,
 {
     let StarkProofWithPublicInputs {
         proof,
@@ -357,7 +357,7 @@ pub fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: usize>(
 ) where
     F: RichField + Extendable<D>,
     C::Hasher: AlgebraicHasher<F>,
-    W: Witness<F>,
+    W: WitnessWrite<F>,
 {
     witness.set_cap_target(&proof_target.trace_cap, &proof.trace_cap);
     if let (Some(quotient_polys_cap_target), Some(quotient_polys_cap)) =


### PR DESCRIPTION
The `set_stark_proof_with_pis_target` function is used in [thie code of starky-bn254](https://github.com/qope/starky-bn254/blob/main/src/fields/fq12_u64/circuit.rs#L210). The [out_buffer](https://github.com/qope/starky-bn254/blob/main/src/fields/fq12_u64/circuit.rs#L210) is type [GeneratedValues](https://docs.rs/plonky2/0.1.4/plonky2/iop/generator/struct.GeneratedValues.html) which only implements [WitnessWrite](https://docs.rs/plonky2/0.1.4/plonky2/iop/witness/trait.WitnessWrite.html), and not implements [Witness](https://docs.rs/plonky2/0.1.4/plonky2/iop/witness/trait.Witness.html).

The `Witness` trait not only implements `WitnessWrite` trait for Setter functions, and also implements Getter functions. But `set_stark_proof_with_pis_target` only needs Setters, since this fix could be compiled successfully.